### PR TITLE
Update dinsync.ino

### DIFF
--- a/dinsync.ino
+++ b/dinsync.ino
@@ -4,6 +4,8 @@
 #define PIN_STARTSTOP 7
 #define CLOCK_DIVIDER 12
 
+MIDI_CREATE_DEFAULT_INSTANCE(); // <-- This was missing. "MIDI.read not defined in scope"
+
 void HandleStart() {
 	digitalWrite(PIN_STARTSTOP, HIGH);
 }


### PR DESCRIPTION
A default instance of MIDI was not defined, causing a scope error.