### PR TITLE
Makes the clock pulse non-blocking

### DIFF
--- a/dinsync.ino
+++ b/dinsync.ino
@@ -4,41 +4,59 @@
 #define PIN_STARTSTOP 7
 #define CLOCK_DIVIDER 12
 
+uint32_t rightNow = 0;          //  a place to store the time the clock pulse is called
+bool clocked = false;           //  says whether a clock pulse has been set (true) or not (false)
+
 MIDI_CREATE_DEFAULT_INSTANCE(); // <-- This was missing. "MIDI.read not defined in scope"
 
 void HandleStart() {
-	digitalWrite(PIN_STARTSTOP, HIGH);
+  digitalWrite(PIN_STARTSTOP, HIGH);
 }
 void HandleContinue() {
-	digitalWrite(PIN_STARTSTOP, HIGH);
+  digitalWrite(PIN_STARTSTOP, HIGH);
 }
 void HandleStop() {
-	digitalWrite(PIN_STARTSTOP, LOW);
+  digitalWrite(PIN_STARTSTOP, LOW);
 }
-void HandleClock() { 
-  digitalWrite(PIN_TRIGGER, HIGH); 
-  delayMicroseconds(2000); 
-  digitalWrite(PIN_TRIGGER, LOW); 
+
+//  Callback changed to non-blocking timing. Arduino can't respond to MIDI commands
+//  if a blocking command like millis() or micros() is counting time.
+void HandleClock() {
+  rightNow = micros();              //  Measure time handleClock is triggered.
+  digitalWrite(PIN_TRIGGER, HIGH);  //  Set DINsync trigger output HIGH.
+  clocked = true;                   //  Set flag so loop knows to turn the
+                                    //  clock pulse off.
+}
+
+//  This new function toggles the clock pulse LOW if clocked variable and 2000uS haven't yet elapsed
+void clockPulseTimeout(){
+  if(micros() >= rightNow + 2000 && clocked == true){   //  tests the condition
+    digitalWrite(PIN_TRIGGER, LOW);                     //  unset PIN_TRIGGER
+    clocked = false;                                    //  UNSET clocked.
+  }
+  //  This timing method ensures there is little chance of losing a stop trigger because 
+  //  a clock pulse is high, as it's non-blocking. Should only take 10 or 20uS,
+  //  instead of 2000uS that delayMicroseconds(2000) takes to run.
 }
 
 // -----------------------------------------------------------------------------
 
 void setup() {
-	MIDI.begin(MIDI_CHANNEL_OMNI);
-	Serial.begin(115200);
-	
-	pinMode(PIN_TRIGGER, OUTPUT);
-	pinMode(PIN_STARTSTOP, OUTPUT);
-	
-	digitalWrite(PIN_TRIGGER, LOW);    
+  MIDI.begin(MIDI_CHANNEL_OMNI);
+  Serial.begin(115200);
   
-	MIDI.setHandleStart(HandleStart);
-	MIDI.setHandleStop(HandleStop);
-	MIDI.setHandleContinue(HandleContinue);
-	MIDI.setHandleClock(HandleClock);
+  pinMode(PIN_TRIGGER, OUTPUT);
+  pinMode(PIN_STARTSTOP, OUTPUT);
+  
+  digitalWrite(PIN_TRIGGER, LOW);    
+  
+  MIDI.setHandleStart(HandleStart);
+  MIDI.setHandleStop(HandleStop);
+  MIDI.setHandleContinue(HandleContinue);
+  MIDI.setHandleClock(HandleClock);
 }
 
-
 void loop() {
-	MIDI.read();
+  MIDI.read();
+  clockPulseTimeout();    //  Calls the new clock pulse timeout function
 }


### PR DESCRIPTION
This pull request makes the clock pulse timeout non-blocking callback changed to non-blocking timing. Arduino can't respond to MIDI commands if a blocking command like millis() or micros() is counting time. Instead of delayMicroseconds(2000), which stops the program for 2000uS, this pull request adds a function, clockPulseTimeout(), to frequently test whether 2000us has elapsed, then unsets the output. It adds 2 new global variables, uint32_t rightNow and bool clocked, as well as the function, itself. The function is called from the main loop, only executing if clocked is true and 2000uS has elapsed since clocked was set. Cheers, Crunchy.